### PR TITLE
Replicate assumption about roles path

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,12 +29,12 @@
 
 - name: Include --check mode detection
   tags: util
-  include: ../../silpion.lib/tasks/checkmodedetection.yml
+  include: "{{ role_path }}/../silpion.lib/tasks/checkmodedetection.yml"
 
 
 - name: Include OS specific configuration
   tags: util
-  include: ../../silpion.lib/tasks/os-specific-vars.yml
+  include: "{{ role_path }}/../silpion.lib/tasks/os-specific-vars.yml"
 
 
 - name: Assert role configuration
@@ -152,6 +152,6 @@
 # Add some facts for other roles to use
 - name: Include local facts tasks
   tags: util
-  include: ../../silpion.lib/tasks/localfacts.yml
+  include: "{{ role_path }}/../silpion.lib/tasks/localfacts.yml"
   vars:
     namespace: util


### PR DESCRIPTION
This is not needed, but will make the code more consistent with the
ansible-java and ansbile-lib repositories.
