### PR TITLE
use check_mode instead of always_run

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -77,7 +77,7 @@
 - name: Register SELinux state
   tags: util
   become: true
-  always_run: true
+  check_mode: no
   ignore_errors: true
   failed_when: false
   changed_when: false
@@ -107,7 +107,7 @@
   when:
     - ansible_os_family == 'RedHat'
     - ansible_local.util.epel.enable is undefined or ansible_local.util.epel.enable != true
-  always_run: true
+  check_mode: no
   register: util_registered_installed_repos
   command: yum repolist
 


### PR DESCRIPTION
Deprecated as of Ansible 2.2.

```
TASK [silpion.util : Register SELinux state] ***********************************
[DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead..
This feature will be
 removed in version 2.4. Deprecation warnings can be disabled by setting deprecation_warnings=False
 in ansible.cfg.
```

https://github.com/willthames/ansible-lint/issues/220

Also, Issues seem to be disabled on this repository, but I have a few I would like to open. Would you be willing to enable them?